### PR TITLE
Add "auto" named export for backward compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Synchronous and asynchronous are now separated into different exports
    - Use `import { onErrorResumeNext } from 'on-error-resume-next'` for synchronous functions
    - Use `import { onErrorResumeNext } from 'on-error-resume-next/async'` for asynchronous functions, will always return `Promise` regardless the resolution and rejection is handled synchronously or asynchronously
-   - Use `import { onErrorResumeNext } from 'on-error-resume-next/auto'` to auto-detect (v1 behavior), will return on `return`/`throw`, and resolve on `resolve`/`reject`
+   - Use `import { onErrorResumeNext } from 'on-error-resume-next/auto'` to auto-detect (legacy behavior), will return on `return`/`throw`, and resolve on `resolve`/`reject`
 
 If you are using v1, you will need to port your code as follow:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Synchronous and asynchronous are now separated into different exports
    - Use `import { onErrorResumeNext } from 'on-error-resume-next'` for synchronous functions
    - Use `import { onErrorResumeNext } from 'on-error-resume-next/async'` for asynchronous functions, will always return `Promise` regardless the resolution and rejection is handled synchronously or asynchronously
-   - Use `import { onErrorResumeNext } from 'on-error-resume-next/auto'` for auto-detect, will return on `return`/`throw`, and resolve on `resolve`/`reject`
+   - Use `import { onErrorResumeNext } from 'on-error-resume-next/auto'` to auto-detect (v1 behavior), will return on `return`/`throw`, and resolve on `resolve`/`reject`
 
 If you are using v1, you will need to port your code as follow:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Synchronous and asynchronous are now separated into different exports
    - Use `import { onErrorResumeNext } from 'on-error-resume-next'` for synchronous operations
    - Use `import { onErrorResumeNext } from 'on-error-resume-next/async'` for asynchronous operations, will always return `Promise` regardless the rejection is handled synchronously or asynchronously
+   - Use `import { onErrorResumeNext } from 'on-error-resume-next/auto'` for auto-detect, will return `undefined` if async function throw synchronously
+
+### Added
+
+- Separated sync, async, and auto version, in PR [#24](https://github.com/compulim/on-error-resume-next/pull/24) and [#25](https://github.com/compulim/on-error-resume-next/pull/25)
 
 ## [1.2.0] - 2020-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Breaking changes
 
-- Inrtoduced named exports and no default imports
+- Inrtoduced named exports and removed default imports
 - Synchronous and asynchronous are now separated into different exports
    - Use `import { onErrorResumeNext } from 'on-error-resume-next'` for synchronous functions
    - Use `import { onErrorResumeNext } from 'on-error-resume-next/async'` for asynchronous functions, will always return `Promise` regardless the resolution and rejection is handled synchronously or asynchronously

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Breaking changes
 
+- Inrtoduced named exports and no default imports
 - Synchronous and asynchronous are now separated into different exports
-   - Use `import { onErrorResumeNext } from 'on-error-resume-next'` for synchronous operations
-   - Use `import { onErrorResumeNext } from 'on-error-resume-next/async'` for asynchronous operations, will always return `Promise` regardless the rejection is handled synchronously or asynchronously
-   - Use `import { onErrorResumeNext } from 'on-error-resume-next/auto'` for auto-detect, will return `undefined` if async function throw synchronously
+   - Use `import { onErrorResumeNext } from 'on-error-resume-next'` for synchronous functions
+   - Use `import { onErrorResumeNext } from 'on-error-resume-next/async'` for asynchronous functions, will always return `Promise` regardless the resolution and rejection is handled synchronously or asynchronously
+   - Use `import { onErrorResumeNext } from 'on-error-resume-next/auto'` for auto-detect, will return on `return`/`throw`, and resolve on `resolve`/`reject`
+
+If you are using v1, you will need to port your code as follow:
+
+```diff
+- import onErrorResumeNext from 'on-error-resume-next';
++ import { onErrorResumeNext } from 'on-error-resume-next/auto';
+```
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ If you are using v1, you will need to port your code as follow:
 
 ### Added
 
-- Separated sync, async, and auto version, in PR [#24](https://github.com/compulim/on-error-resume-next/pull/24) and [#25](https://github.com/compulim/on-error-resume-next/pull/25)
+- Added synchronous and asynchronous versions, in PR [#24](https://github.com/compulim/on-error-resume-next/pull/24) and [#25](https://github.com/compulim/on-error-resume-next/pull/25)
 
 ## [1.2.0] - 2020-05-26
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ When using `onErrorResumeNext`, please be responsible and fully understand the i
 
 We introduced named exports and no default imports. The default is synchronous. The "auto async" version is being moved to under 'on-error-resume-next/auto'.
 
-````diff
+```diff
 - import onErrorResumeNext from 'on-error-resume-next';
 + import { onErrorResumeNext } from 'on-error-resume-next/auto';
 ```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ When using `onErrorResumeNext`, please be responsible and fully understand the i
 
 ## New in 2.0
 
-We introduced named exports and no default imports. The default is synchronous. The "auto async" version is being moved to under 'on-error-resume-next/auto'.
+We introduced named exports and removed default imports. The default is synchronous. The "auto async" version is being moved to under 'on-error-resume-next/auto'.
 
 ```diff
 - import onErrorResumeNext from 'on-error-resume-next';

--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ It is recommended to use either synchronous or asynchronous version for better c
 import { onErrorResumeNext } from 'on-error-resume-next';
 
 // Will return result on returns.
-const parsed = onErrorResumeNext(() => JSON.parse('{"hello":"World!"}'));
+const returned = onErrorResumeNext(() => JSON.parse('{"hello":"World!"}'));
 
-expect(parsed).toEqual({ hello: 'World!' });
+expect(returned).toEqual({ hello: 'World!' });
 
 // Will return undefined on throws.
-const cannotParsed = onErrorResumeNext(() => JSON.parse('<xml />'));
+const thrown = onErrorResumeNext(() => JSON.parse('<xml />'));
 
-expect(cannotParsed).toBeUndefined();
+expect(thrown).toBeUndefined();
 ```
 
 Notes: if an asynchronous function is being passed to `onErrorResumeNext()`, it will throw to protect from false negatives. Please use `on-error-resume-next/async` for asynchronous functions.
@@ -56,9 +56,9 @@ const resolution = onErrorResumeNext(() => Promise.resolve('Hello, World!'));
 await expect(resolution).resolves.toBe('Hello, World!');
 
 // "async" will return Promise on returns.
-const resolution = onErrorResumeNext(() => 'Hello, World!');
+const returned = onErrorResumeNext(() => 'Hello, World!');
 
-await expect(resolution).resolves.toBe('Hello, World!');
+await expect(returned).resolves.toBe('Hello, World!');
 
 // "async" will return Promise on rejects.
 const rejection = onErrorResumeNext(() => Promise.reject(new Error()));

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ await expect(rejection).resolves.toBeUndefined();
 
 The following table show how each version react with different passing functions.
 
-|                      | Default (sync)            | 'async'                      | 'auto'                       |
+|                      | Default (sync)            | Async                        | Auto                         |
 | -------------------- | ------------------------- | ---------------------------- | ---------------------------- |
 | `return 1`           | `1`                       | `Promise.resolve(1)`         | `1`                          |
 | `throw 2`            | `undefined`               | `Promise.resolve(undefined)` | `undefined`                  |

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ When using `onErrorResumeNext`, please be responsible and fully understand the i
 
 ## New in 2.0
 
-We introduced named exports and removed default imports. The default is synchronous. The "auto async" version is being moved to under 'on-error-resume-next/auto'.
+We introduced named exports and removed default imports. The default is synchronous. The "auto-detection" version is being moved to under 'on-error-resume-next/auto'.
 
 ```diff
 - import onErrorResumeNext from 'on-error-resume-next';
 + import { onErrorResumeNext } from 'on-error-resume-next/auto';
 ```
 
-It is recommended to use either sync or async version for better clarity.
+It is recommended to use either synchronous or asynchronous version for better clarity.
 
 # Usage
 
@@ -39,19 +39,24 @@ expect(parsed).toEqual({ hello: 'World!' });
 const cannotParsed = onErrorResumeNext(() => JSON.parse('<xml />'));
 
 expect(cannotParsed).toBeUndefined();
-````
+```
 
-If an asynchronous function is being passed to `onErrorResumeNext()`, it will throw to protect itself from false negatives as it will ignore rejections. Please use `on-error-resume-next/async` for asynchronous functions.
+Notes: if an asynchronous function is being passed to `onErrorResumeNext()`, it will throw to protect from false negatives. Please use `on-error-resume-next/async` for asynchronous functions.
 
-## Asynchronous using async/await
+## Asynchronous using `async`/`await`
 
-`onErrorResumeNext` will capture both exceptions (synchronous) and rejections (asynchronous).
+`onErrorResumeNext` will capture both exceptions (synchronous) and rejections (asynchronous). The returned value is always a `Promise` object.
 
 ```js
 import { onErrorResumeNext } from 'on-error-resume-next/async';
 
 // "async" will return Promise on resolves.
 const resolution = onErrorResumeNext(() => Promise.resolve('Hello, World!'));
+
+await expect(resolution).resolves.toBe('Hello, World!');
+
+// "async" will return Promise on returns.
+const resolution = onErrorResumeNext(() => 'Hello, World!');
 
 await expect(resolution).resolves.toBe('Hello, World!');
 
@@ -68,9 +73,9 @@ const thrown = onErrorResumeNext(() => {
 await expect(thrown).resolves.toBeUndefined();
 ```
 
-## Auto-detecting synchronous/asynchronous operations
+## Auto-detecting synchronous/asynchronous functions
 
-> For best experience, please use sync or async version instead.
+> For best experience, please use synchronous or asynchronous version instead.
 
 `on-error-resume-next/auto` will handle both exceptions (synchronous) and rejections (asynchronous) accordingly.
 
@@ -101,6 +106,8 @@ await expect(rejection).resolves.toBeUndefined();
 ```
 
 ## Sync vs. async vs. auto
+
+The following table show how each version react with different passing functions.
 
 |                      | Default (sync)            | 'async'                      | 'auto'                       |
 | -------------------- | ------------------------- | ---------------------------- | ---------------------------- |

--- a/README.md
+++ b/README.md
@@ -2,48 +2,112 @@
 
 Run a function, synchronously or asynchronously, and ignore errors.
 
-[![npm version](https://badge.fury.io/js/on-error-resume-next.svg)](https://badge.fury.io/js/on-error-resume-next) [![Build Status](https://travis-ci.org/compulim/on-error-resume-next.svg?branch=master)](https://travis-ci.org/compulim/on-error-resume-next)
+[![npm version](https://badge.fury.io/js/on-error-resume-next.svg)](https://npmjs.com/package/on-error-resume-next)
 
 The name come from [Visual Basic](https://docs.microsoft.com/en-us/dotnet/visual-basic/language-reference/statements/on-error-statement). The original `On Error Resume Next` statement is considered a bad error handling practice.
 
 Although the perception of the feature is negative, when scoped and used responsibly, it can become a very helpful utility function.
 
+When using `onErrorResumeNext`, please be responsible and fully understand the impact of ignoring errors.
+
 # Breaking changes
+
+## New in 2.0
+
+We introduced named exports and no default imports. The default is synchronous. The "auto async" version is being moved to under 'on-error-resume-next/auto'.
+
+````diff
+- import onErrorResumeNext from 'on-error-resume-next';
++ import { onErrorResumeNext } from 'on-error-resume-next/auto';
+```
+
+It is recommended to use either sync or async version for better clarity.
 
 # Usage
 
 `onErrorResumeNext` will return the result if it is a success. For example,
 
 ```js
-import onErrorResumeNext from 'on-error-resume-next';
+import { onErrorResumeNext } from 'on-error-resume-next';
 
-const text = '{"hello":"World!"}';
-const parsed = onErrorResumeNext(() => JSON.parse(text));
+// Will return result on returns.
+const parsed = onErrorResumeNext(() => JSON.parse('{"hello":"World!"}'));
 
 expect(parsed).toEqual({ hello: 'World!' });
-```
 
-Otherwise, it will return `undefined`,
+// Will return undefined on throws.
+const cannotParsed = onErrorResumeNext(() => JSON.parse('<xml />'));
 
-```js
-const parsed = onErrorResumeNext(() => JSON.parse('<xml />'));
+expect(cannotParsed).toBeUndefined();
+````
 
-expect(parsed).toBeUndefined();
-```
-
-> When using `onErrorResumeNext`, please be responsible and fully understand the impact of ignoring errors.
+If an asynchronous function is being passed to `onErrorResumeNext()`, it will throw to protect itself from false negatives as it will ignore rejections. Please use `on-error-resume-next/async` for asynchronous functions.
 
 ## Asynchronous using async/await
 
 `onErrorResumeNext` will capture both exceptions (synchronous) and rejections (asynchronous).
 
 ```js
-import onErrorResumeNext from 'on-error-resume-next/async';
+import { onErrorResumeNext } from 'on-error-resume-next/async';
 
-const res = await onErrorResumeNext(() => fetch('/health'));
+// "async" will return Promise on resolves.
+const resolution = onErrorResumeNext(() => Promise.resolve('Hello, World!'));
 
-await expect(res).resolves.toBeUndefined();
+await expect(resolution).resolves.toBe('Hello, World!');
+
+// "async" will return Promise on rejects.
+const rejection = onErrorResumeNext(() => Promise.reject(new Error()));
+
+await expect(rejection).resolves.toBeUndefined();
+
+// "async" will return Promise on throws.
+const thrown = onErrorResumeNext(() => {
+  throw new Error();
+});
+
+await expect(thrown).resolves.toBeUndefined();
 ```
+
+## Auto-detecting synchronous/asynchronous operations
+
+> For best experience, please use sync or async version instead.
+
+`on-error-resume-next/auto` will handle both exceptions (synchronous) and rejections (asynchronous) accordingly.
+
+```js
+import { onErrorResumeNext } from 'on-error-resume-next/auto';
+
+// "auto" will return result on returns.
+const returned = onErrorResumeNext(() => 'Hello, World!');
+
+expect(returned).toEqual('Hello, World!');
+
+// "auto" will return undefined on throws.
+const thrown = onErrorResumeNext(() => {
+  throw new Error('Hello, World!');
+});
+
+expect(thrown).toEqual(undefined);
+
+// "auto" will return Promise on resolves.
+const resolution = onErrorResumeNext(() => Promise.resolve('Hello, World!'));
+
+await expect(resolution).resolves.toBe('Hello, World!');
+
+// "auto" will return Promise on rejects.
+const rejection = onErrorResumeNext(() => Promise.reject(new Error()));
+
+await expect(rejection).resolves.toBeUndefined();
+```
+
+## Sync vs. async vs. auto
+
+|                      | Default (sync)            | 'async'                      | 'auto'                       |
+| -------------------- | ------------------------- | ---------------------------- | ---------------------------- |
+| `return 1`           | `1`                       | `Promise.resolve(1)`         | `1`                          |
+| `throw 2`            | `undefined`               | `Promise.resolve(undefined)` | `undefined`                  |
+| `Promise.resolve(3)` | Not supported, will throw | `Promise.resolve(3)`         | `Promise.resolve(3)`         |
+| `Promise.reject(4)`  | Not supported, will throw | `Promise.resolve(undefined)` | `Promise.resolve(undefined)` |
 
 # Contributions
 

--- a/packages/integration-test/importDefault.test.mjs
+++ b/packages/integration-test/importDefault.test.mjs
@@ -198,22 +198,4 @@ describe('auto', () => {
     test('should call the function once', () => expect(fn).toHaveBeenCalledTimes(1));
     test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
   });
-
-  describe('reject', () => {
-    let fn;
-    let resultPromise;
-    let thisArg;
-
-    beforeEach(() => {
-      fn = jest.fn(() => {
-        throw new Error('Hello, World!');
-      });
-      thisArg = {};
-      resultPromise = onErrorResumeNextAuto(fn, thisArg);
-    });
-
-    test('should return undefined', () => expect(resultPromise).toBeUndefined());
-    test('should call the function once', () => expect(fn).toHaveBeenCalledTimes(1));
-    test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
-  });
 });

--- a/packages/integration-test/importDefault.test.mjs
+++ b/packages/integration-test/importDefault.test.mjs
@@ -1,24 +1,219 @@
-import { onErrorResumeNext } from 'on-error-resume-next';
+import { onErrorResumeNext as onErrorResumeNextSync } from 'on-error-resume-next';
 import { onErrorResumeNext as onErrorResumeNextAsync } from 'on-error-resume-next/async';
+import { onErrorResumeNext as onErrorResumeNextAuto } from 'on-error-resume-next/auto';
 
-describe('simple sync scenario', () => {
-  let result;
+describe('sync', () => {
+  describe('return', () => {
+    let actual;
+    let fn;
+    let thisArg;
 
-  beforeEach(() => {
-    result = onErrorResumeNext(() => {
-      throw new Error('Artificial error.');
+    beforeEach(() => {
+      fn = jest.fn(() => JSON.parse('"Hello, World!"'));
+      thisArg = {};
+      actual = onErrorResumeNextSync(fn, thisArg);
     });
+
+    test('should return the result', () => expect(actual).toBe('Hello, World!'));
+    test('should call the function once', () => expect(fn).toHaveBeenCalledTimes(1));
+    test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
   });
 
-  test('should work', () => expect(result).toBeUndefined());
+  describe('throw', () => {
+    let actual;
+    let fn;
+    let thisArg;
+
+    beforeEach(() => {
+      fn = jest.fn(() => JSON.parse('error'));
+      thisArg = {};
+      actual = onErrorResumeNextSync(fn, thisArg);
+    });
+
+    test('should return undefined', () => expect(actual).toBeUndefined());
+    test('should call the function once', () => expect(fn).toHaveBeenCalledTimes(1));
+    test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
+  });
+
+  describe('resolve', () => {
+    let fn;
+    let thisArg;
+
+    beforeEach(() => {
+      fn = jest.fn(() => Promise.resolve(1));
+      thisArg = {};
+    });
+
+    test('should throw', () => expect(() => onErrorResumeNextSync(fn, thisArg)).toThrow());
+  });
+
+  describe('reject', () => {
+    let fn;
+    let thisArg;
+
+    beforeEach(() => {
+      fn = jest.fn(() => Promise.reject(new Error('error')).catch(() => {}));
+      thisArg = {};
+    });
+
+    test('should throw', () => expect(() => onErrorResumeNextSync(fn, thisArg)).toThrow());
+  });
 });
 
-describe('simple async scenario', () => {
-  let result;
+describe('async', () => {
+  describe('return', () => {
+    let fn;
+    let resultPromise;
+    let thisArg;
 
-  beforeEach(async () => {
-    result = await onErrorResumeNextAsync(() => Promise.reject('Artificial error.'));
+    beforeEach(() => {
+      fn = jest.fn(() => 'Hello, World!');
+      thisArg = {};
+      resultPromise = onErrorResumeNextAsync(fn, thisArg);
+    });
+
+    test('should return a Promise', () => expect(typeof resultPromise.then).toBe('function'));
+    test('should resolve to the result', () => expect(resultPromise).resolves.toBe('Hello, World!'));
+    test('should call the function once', () => expect(fn).toHaveBeenCalledTimes(1));
+    test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
   });
 
-  test('should work', () => expect(result).toBeUndefined());
+  describe('throw', () => {
+    let fn;
+    let resultPromise;
+    let thisArg;
+
+    beforeEach(() => {
+      fn = jest.fn(() => {
+        throw new Error('Hello, World!');
+      });
+      thisArg = {};
+      resultPromise = onErrorResumeNextAsync(fn, thisArg);
+    });
+
+    test('should return a Promise', () => expect(typeof resultPromise.then).toBe('function'));
+    test('should resolve to undefined', () => expect(resultPromise).resolves.toBeUndefined());
+    test('should call the function once', () => expect(fn).toHaveBeenCalledTimes(1));
+    test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
+  });
+
+  describe('resolve', () => {
+    let fn;
+    let resultPromise;
+    let thisArg;
+
+    beforeEach(() => {
+      fn = jest.fn(() => Promise.resolve('Hello, World!'));
+      thisArg = {};
+      resultPromise = onErrorResumeNextAsync(fn, thisArg);
+    });
+
+    test('should return a Promise', () => expect(typeof resultPromise.then).toBe('function'));
+    test('should resolve to the result', () => expect(resultPromise).resolves.toBe('Hello, World!'));
+    test('should call the function once', () => expect(fn).toHaveBeenCalledTimes(1));
+    test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
+  });
+
+  describe('reject', () => {
+    let fn;
+    let resultPromise;
+    let thisArg;
+
+    beforeEach(() => {
+      fn = jest.fn(() => Promise.reject(new Error('Hello, World!')));
+      thisArg = {};
+      resultPromise = onErrorResumeNextAsync(fn, thisArg);
+    });
+
+    test('should return a Promise', () => expect(typeof resultPromise.then).toBe('function'));
+    test('should resolve to undefined', () => expect(resultPromise).resolves.toBeUndefined());
+    test('should call the function once', () => expect(fn).toHaveBeenCalledTimes(1));
+    test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
+  });
+});
+
+describe('auto', () => {
+  describe('return', () => {
+    let actual;
+    let fn;
+    let thisArg;
+
+    beforeEach(() => {
+      fn = jest.fn(() => JSON.parse('"Hello, World!"'));
+      thisArg = {};
+      actual = onErrorResumeNextAuto(fn, thisArg);
+    });
+
+    test('should return the result', () => expect(actual).toBe('Hello, World!'));
+    test('should call the function once', () => expect(fn).toHaveBeenCalledTimes(1));
+    test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
+  });
+
+  describe('throw', () => {
+    let actual;
+    let fn;
+    let thisArg;
+
+    beforeEach(() => {
+      fn = jest.fn(() => JSON.parse('error'));
+      thisArg = {};
+      actual = onErrorResumeNextAuto(fn, thisArg);
+    });
+
+    test('should return undefined', () => expect(actual).toBeUndefined());
+    test('should call the function once', () => expect(fn).toHaveBeenCalledTimes(1));
+    test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
+  });
+
+  describe('resolve', () => {
+    let fn;
+    let resultPromise;
+    let thisArg;
+
+    beforeEach(() => {
+      fn = jest.fn(() => Promise.resolve('Hello, World!'));
+      thisArg = {};
+      resultPromise = onErrorResumeNextAuto(fn, thisArg);
+    });
+
+    test('should return a Promise', () => expect(typeof resultPromise?.then).toBe('function'));
+    test('should resolve to the result', () => expect(resultPromise).resolves.toBe('Hello, World!'));
+    test('should call the function once', () => expect(fn).toHaveBeenCalledTimes(1));
+    test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
+  });
+
+  describe('promise failed asynchronously', () => {
+    let fn;
+    let resultPromise;
+    let thisArg;
+
+    beforeEach(() => {
+      fn = jest.fn(() => Promise.reject(new Error('Hello, World!')));
+      thisArg = {};
+      resultPromise = onErrorResumeNextAuto(fn, thisArg);
+    });
+
+    test('should return a Promise', () => expect(typeof resultPromise?.then).toBe('function'));
+    test('should resolve to undefined', () => expect(resultPromise).resolves.toBeUndefined());
+    test('should call the function once', () => expect(fn).toHaveBeenCalledTimes(1));
+    test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
+  });
+
+  describe('reject', () => {
+    let fn;
+    let resultPromise;
+    let thisArg;
+
+    beforeEach(() => {
+      fn = jest.fn(() => {
+        throw new Error('Hello, World!');
+      });
+      thisArg = {};
+      resultPromise = onErrorResumeNextAuto(fn, thisArg);
+    });
+
+    test('should return undefined', () => expect(resultPromise).toBeUndefined());
+    test('should call the function once', () => expect(fn).toHaveBeenCalledTimes(1));
+    test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
+  });
 });

--- a/packages/integration-test/importDefault.test.mjs
+++ b/packages/integration-test/importDefault.test.mjs
@@ -182,7 +182,7 @@ describe('auto', () => {
     test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
   });
 
-  describe('promise failed asynchronously', () => {
+  describe('reject', () => {
     let fn;
     let resultPromise;
     let thisArg;

--- a/packages/integration-test/requireDefault.test.cjs
+++ b/packages/integration-test/requireDefault.test.cjs
@@ -198,22 +198,4 @@ describe('auto', () => {
     test('should call the function once', () => expect(fn).toHaveBeenCalledTimes(1));
     test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
   });
-
-  describe('reject', () => {
-    let fn;
-    let resultPromise;
-    let thisArg;
-
-    beforeEach(() => {
-      fn = jest.fn(() => {
-        throw new Error('Hello, World!');
-      });
-      thisArg = {};
-      resultPromise = onErrorResumeNextAuto(fn, thisArg);
-    });
-
-    test('should return undefined', () => expect(resultPromise).toBeUndefined());
-    test('should call the function once', () => expect(fn).toHaveBeenCalledTimes(1));
-    test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
-  });
 });

--- a/packages/integration-test/requireDefault.test.cjs
+++ b/packages/integration-test/requireDefault.test.cjs
@@ -182,7 +182,7 @@ describe('auto', () => {
     test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
   });
 
-  describe('promise failed asynchronously', () => {
+  describe('reject', () => {
     let fn;
     let resultPromise;
     let thisArg;

--- a/packages/integration-test/requireDefault.test.cjs
+++ b/packages/integration-test/requireDefault.test.cjs
@@ -1,24 +1,219 @@
-const { onErrorResumeNext } = require('on-error-resume-next');
+const { onErrorResumeNext: onErrorResumeNextSync } = require('on-error-resume-next');
 const { onErrorResumeNext: onErrorResumeNextAsync } = require('on-error-resume-next/async');
+const { onErrorResumeNext: onErrorResumeNextAuto } = require('on-error-resume-next/auto');
 
-describe('simple sync scenario', () => {
-  let result;
+describe('sync', () => {
+  describe('return', () => {
+    let actual;
+    let fn;
+    let thisArg;
 
-  beforeEach(() => {
-    result = onErrorResumeNext(() => {
-      throw new Error('Artificial error.');
+    beforeEach(() => {
+      fn = jest.fn(() => JSON.parse('"Hello, World!"'));
+      thisArg = {};
+      actual = onErrorResumeNextSync(fn, thisArg);
     });
+
+    test('should return the result', () => expect(actual).toBe('Hello, World!'));
+    test('should call the function once', () => expect(fn).toHaveBeenCalledTimes(1));
+    test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
   });
 
-  test('should work', () => expect(result).toBeUndefined());
+  describe('throw', () => {
+    let actual;
+    let fn;
+    let thisArg;
+
+    beforeEach(() => {
+      fn = jest.fn(() => JSON.parse('error'));
+      thisArg = {};
+      actual = onErrorResumeNextSync(fn, thisArg);
+    });
+
+    test('should return undefined', () => expect(actual).toBeUndefined());
+    test('should call the function once', () => expect(fn).toHaveBeenCalledTimes(1));
+    test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
+  });
+
+  describe('resolve', () => {
+    let fn;
+    let thisArg;
+
+    beforeEach(() => {
+      fn = jest.fn(() => Promise.resolve(1));
+      thisArg = {};
+    });
+
+    test('should throw', () => expect(() => onErrorResumeNextSync(fn, thisArg)).toThrow());
+  });
+
+  describe('reject', () => {
+    let fn;
+    let thisArg;
+
+    beforeEach(() => {
+      fn = jest.fn(() => Promise.reject(new Error('error')).catch(() => {}));
+      thisArg = {};
+    });
+
+    test('should throw', () => expect(() => onErrorResumeNextSync(fn, thisArg)).toThrow());
+  });
 });
 
-describe('simple async scenario', () => {
-  let result;
+describe('async', () => {
+  describe('return', () => {
+    let fn;
+    let resultPromise;
+    let thisArg;
 
-  beforeEach(async () => {
-    result = await onErrorResumeNextAsync(() => Promise.reject('Artificial error.'));
+    beforeEach(() => {
+      fn = jest.fn(() => 'Hello, World!');
+      thisArg = {};
+      resultPromise = onErrorResumeNextAsync(fn, thisArg);
+    });
+
+    test('should return a Promise', () => expect(typeof resultPromise.then).toBe('function'));
+    test('should resolve to the result', () => expect(resultPromise).resolves.toBe('Hello, World!'));
+    test('should call the function once', () => expect(fn).toHaveBeenCalledTimes(1));
+    test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
   });
 
-  test('should work', () => expect(result).toBeUndefined());
+  describe('throw', () => {
+    let fn;
+    let resultPromise;
+    let thisArg;
+
+    beforeEach(() => {
+      fn = jest.fn(() => {
+        throw new Error('Hello, World!');
+      });
+      thisArg = {};
+      resultPromise = onErrorResumeNextAsync(fn, thisArg);
+    });
+
+    test('should return a Promise', () => expect(typeof resultPromise.then).toBe('function'));
+    test('should resolve to undefined', () => expect(resultPromise).resolves.toBeUndefined());
+    test('should call the function once', () => expect(fn).toHaveBeenCalledTimes(1));
+    test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
+  });
+
+  describe('resolve', () => {
+    let fn;
+    let resultPromise;
+    let thisArg;
+
+    beforeEach(() => {
+      fn = jest.fn(() => Promise.resolve('Hello, World!'));
+      thisArg = {};
+      resultPromise = onErrorResumeNextAsync(fn, thisArg);
+    });
+
+    test('should return a Promise', () => expect(typeof resultPromise.then).toBe('function'));
+    test('should resolve to the result', () => expect(resultPromise).resolves.toBe('Hello, World!'));
+    test('should call the function once', () => expect(fn).toHaveBeenCalledTimes(1));
+    test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
+  });
+
+  describe('reject', () => {
+    let fn;
+    let resultPromise;
+    let thisArg;
+
+    beforeEach(() => {
+      fn = jest.fn(() => Promise.reject(new Error('Hello, World!')));
+      thisArg = {};
+      resultPromise = onErrorResumeNextAsync(fn, thisArg);
+    });
+
+    test('should return a Promise', () => expect(typeof resultPromise.then).toBe('function'));
+    test('should resolve to undefined', () => expect(resultPromise).resolves.toBeUndefined());
+    test('should call the function once', () => expect(fn).toHaveBeenCalledTimes(1));
+    test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
+  });
+});
+
+describe('auto', () => {
+  describe('return', () => {
+    let actual;
+    let fn;
+    let thisArg;
+
+    beforeEach(() => {
+      fn = jest.fn(() => JSON.parse('"Hello, World!"'));
+      thisArg = {};
+      actual = onErrorResumeNextAuto(fn, thisArg);
+    });
+
+    test('should return the result', () => expect(actual).toBe('Hello, World!'));
+    test('should call the function once', () => expect(fn).toHaveBeenCalledTimes(1));
+    test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
+  });
+
+  describe('throw', () => {
+    let actual;
+    let fn;
+    let thisArg;
+
+    beforeEach(() => {
+      fn = jest.fn(() => JSON.parse('error'));
+      thisArg = {};
+      actual = onErrorResumeNextAuto(fn, thisArg);
+    });
+
+    test('should return undefined', () => expect(actual).toBeUndefined());
+    test('should call the function once', () => expect(fn).toHaveBeenCalledTimes(1));
+    test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
+  });
+
+  describe('resolve', () => {
+    let fn;
+    let resultPromise;
+    let thisArg;
+
+    beforeEach(() => {
+      fn = jest.fn(() => Promise.resolve('Hello, World!'));
+      thisArg = {};
+      resultPromise = onErrorResumeNextAuto(fn, thisArg);
+    });
+
+    test('should return a Promise', () => expect(typeof resultPromise?.then).toBe('function'));
+    test('should resolve to the result', () => expect(resultPromise).resolves.toBe('Hello, World!'));
+    test('should call the function once', () => expect(fn).toHaveBeenCalledTimes(1));
+    test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
+  });
+
+  describe('promise failed asynchronously', () => {
+    let fn;
+    let resultPromise;
+    let thisArg;
+
+    beforeEach(() => {
+      fn = jest.fn(() => Promise.reject(new Error('Hello, World!')));
+      thisArg = {};
+      resultPromise = onErrorResumeNextAuto(fn, thisArg);
+    });
+
+    test('should return a Promise', () => expect(typeof resultPromise?.then).toBe('function'));
+    test('should resolve to undefined', () => expect(resultPromise).resolves.toBeUndefined());
+    test('should call the function once', () => expect(fn).toHaveBeenCalledTimes(1));
+    test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
+  });
+
+  describe('reject', () => {
+    let fn;
+    let resultPromise;
+    let thisArg;
+
+    beforeEach(() => {
+      fn = jest.fn(() => {
+        throw new Error('Hello, World!');
+      });
+      thisArg = {};
+      resultPromise = onErrorResumeNextAuto(fn, thisArg);
+    });
+
+    test('should return undefined', () => expect(resultPromise).toBeUndefined());
+    test('should call the function once', () => expect(fn).toHaveBeenCalledTimes(1));
+    test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
+  });
 });

--- a/packages/on-error-resume-next/package.json
+++ b/packages/on-error-resume-next/package.json
@@ -25,6 +25,16 @@
         "types": "./dist/on-error-resume-next.async.d.ts",
         "default": "./dist/on-error-resume-next.async.js"
       }
+    },
+    "./auto": {
+      "import": {
+        "types": "./dist/on-error-resume-next.auto.d.mts",
+        "default": "./dist/on-error-resume-next.auto.mjs"
+      },
+      "require": {
+        "types": "./dist/on-error-resume-next.auto.d.ts",
+        "default": "./dist/on-error-resume-next.auto.js"
+      }
     }
   },
   "main": "./dist/on-error-resume-next.js",

--- a/packages/on-error-resume-next/src/index.async.ts
+++ b/packages/on-error-resume-next/src/index.async.ts
@@ -1,3 +1,5 @@
+import { isPromise } from 'util/types';
+
 export function onErrorResumeNext<T extends () => Promise<U>, U = unknown>(
   fn: T,
   context?: undefined
@@ -12,5 +14,17 @@ export function onErrorResumeNext<T extends (this: V) => Promise<U>, U = unknown
   fn: T,
   context: V
 ): Promise<U | undefined> {
-  return new Promise<U | undefined>(resolve => fn.call(context).then(resolve, () => resolve(undefined)));
+  return new Promise<U | undefined>(resolve => {
+    try {
+      const result = fn.call(context);
+
+      if (isPromise(result)) {
+        result.then(resolve, () => resolve(undefined));
+      } else {
+        resolve(result);
+      }
+    } catch {
+      resolve(undefined);
+    }
+  });
 }

--- a/packages/on-error-resume-next/src/index.auto.spec.ts
+++ b/packages/on-error-resume-next/src/index.auto.spec.ts
@@ -1,26 +1,74 @@
-import { onErrorResumeNext } from './index.async';
+import { onErrorResumeNext } from './index.auto';
 
 describe('return', () => {
+  let actual: string | undefined;
   let fn: jest.Mock<string>;
-  let resultPromise: Promise<string | undefined>;
   let thisArg: object;
 
   beforeEach(() => {
-    fn = jest.fn(() => 'Hello, World!');
+    fn = jest.fn(() => JSON.parse('"Hello, World!"'));
     thisArg = {};
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    resultPromise = onErrorResumeNext(fn as any, thisArg);
+    actual = onErrorResumeNext(fn, thisArg);
   });
 
-  test('should return a Promise', () => expect(typeof resultPromise.then).toBe('function'));
-  test('should resolve to the result', () => expect(resultPromise).resolves.toBe('Hello, World!'));
+  test('should return the result', () => expect(actual).toBe('Hello, World!'));
   test('should call the function once', () => expect(fn).toHaveBeenCalledTimes(1));
   test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
 });
 
 describe('throw', () => {
-  let fn: jest.Mock<never>;
-  let resultPromise: Promise<string | undefined>;
+  let actual: string | undefined;
+  let fn: jest.Mock<string>;
+  let thisArg: object;
+
+  beforeEach(() => {
+    fn = jest.fn(() => JSON.parse('error'));
+    thisArg = {};
+    actual = onErrorResumeNext(fn, thisArg);
+  });
+
+  test('should return undefined', () => expect(actual).toBeUndefined());
+  test('should call the function once', () => expect(fn).toHaveBeenCalledTimes(1));
+  test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
+});
+
+describe('resolve', () => {
+  let fn: jest.Mock<Promise<string>>;
+  let resultPromise: Promise<string | undefined> | undefined;
+  let thisArg: object;
+
+  beforeEach(() => {
+    fn = jest.fn(() => Promise.resolve('Hello, World!'));
+    thisArg = {};
+    resultPromise = onErrorResumeNext(fn, thisArg);
+  });
+
+  test('should return a Promise', () => expect(typeof resultPromise?.then).toBe('function'));
+  test('should resolve to the result', () => expect(resultPromise).resolves.toBe('Hello, World!'));
+  test('should call the function once', () => expect(fn).toHaveBeenCalledTimes(1));
+  test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
+});
+
+describe('promise failed asynchronously', () => {
+  let fn: jest.Mock<Promise<never>>;
+  let resultPromise: Promise<string | undefined> | undefined;
+  let thisArg: object;
+
+  beforeEach(() => {
+    fn = jest.fn(() => Promise.reject(new Error('Hello, World!')));
+    thisArg = {};
+    resultPromise = onErrorResumeNext(fn, thisArg);
+  });
+
+  test('should return a Promise', () => expect(typeof resultPromise?.then).toBe('function'));
+  test('should resolve to undefined', () => expect(resultPromise).resolves.toBeUndefined());
+  test('should call the function once', () => expect(fn).toHaveBeenCalledTimes(1));
+  test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
+});
+
+describe('reject', () => {
+  let fn: jest.Mock<Promise<never>>;
+  let resultPromise: Promise<string | undefined> | undefined;
   let thisArg: object;
 
   beforeEach(() => {
@@ -31,42 +79,7 @@ describe('throw', () => {
     resultPromise = onErrorResumeNext(fn, thisArg);
   });
 
-  test('should return a Promise', () => expect(typeof resultPromise.then).toBe('function'));
-  test('should resolve to undefined', () => expect(resultPromise).resolves.toBeUndefined());
-  test('should call the function once', () => expect(fn).toHaveBeenCalledTimes(1));
-  test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
-});
-
-describe('resolve', () => {
-  let fn: jest.Mock<Promise<string>>;
-  let resultPromise: Promise<string | undefined>;
-  let thisArg: object;
-
-  beforeEach(() => {
-    fn = jest.fn(() => Promise.resolve('Hello, World!'));
-    thisArg = {};
-    resultPromise = onErrorResumeNext(fn, thisArg);
-  });
-
-  test('should return a Promise', () => expect(typeof resultPromise.then).toBe('function'));
-  test('should resolve to the result', () => expect(resultPromise).resolves.toBe('Hello, World!'));
-  test('should call the function once', () => expect(fn).toHaveBeenCalledTimes(1));
-  test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
-});
-
-describe('reject', () => {
-  let fn: jest.Mock<Promise<never>>;
-  let resultPromise: Promise<string | undefined>;
-  let thisArg: object;
-
-  beforeEach(() => {
-    fn = jest.fn(() => Promise.reject(new Error('Hello, World!')));
-    thisArg = {};
-    resultPromise = onErrorResumeNext(fn, thisArg);
-  });
-
-  test('should return a Promise', () => expect(typeof resultPromise.then).toBe('function'));
-  test('should resolve to undefined', () => expect(resultPromise).resolves.toBeUndefined());
+  test('should return undefined', () => expect(resultPromise).toBeUndefined());
   test('should call the function once', () => expect(fn).toHaveBeenCalledTimes(1));
   test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
 });

--- a/packages/on-error-resume-next/src/index.auto.spec.ts
+++ b/packages/on-error-resume-next/src/index.auto.spec.ts
@@ -49,7 +49,7 @@ describe('resolve', () => {
   test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
 });
 
-describe('promise failed asynchronously', () => {
+describe('reject', () => {
   let fn: jest.Mock<Promise<never>>;
   let resultPromise: Promise<string | undefined> | undefined;
   let thisArg: object;

--- a/packages/on-error-resume-next/src/index.auto.spec.ts
+++ b/packages/on-error-resume-next/src/index.auto.spec.ts
@@ -65,21 +65,3 @@ describe('reject', () => {
   test('should call the function once', () => expect(fn).toHaveBeenCalledTimes(1));
   test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
 });
-
-describe('reject', () => {
-  let fn: jest.Mock<Promise<never>>;
-  let resultPromise: Promise<string | undefined> | undefined;
-  let thisArg: object;
-
-  beforeEach(() => {
-    fn = jest.fn(() => {
-      throw new Error('Hello, World!');
-    });
-    thisArg = {};
-    resultPromise = onErrorResumeNext(fn, thisArg);
-  });
-
-  test('should return undefined', () => expect(resultPromise).toBeUndefined());
-  test('should call the function once', () => expect(fn).toHaveBeenCalledTimes(1));
-  test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
-});

--- a/packages/on-error-resume-next/src/index.auto.ts
+++ b/packages/on-error-resume-next/src/index.auto.ts
@@ -1,0 +1,34 @@
+import isPromise from './private/isPromise';
+
+export function onErrorResumeNext<T extends () => U, U = unknown>(fn: T, context?: undefined): U | undefined;
+export function onErrorResumeNext<T extends (this: V) => U, U = unknown, V = undefined>(
+  fn: T,
+  context: V
+): U | undefined;
+
+export function onErrorResumeNext<T extends () => Promise<U>, U = unknown>(
+  fn: T,
+  context?: undefined
+): Promise<U | undefined>;
+
+export function onErrorResumeNext<T extends (this: V) => Promise<U>, U = unknown, V = undefined>(
+  fn: T,
+  context: V
+): Promise<U | undefined>;
+
+export function onErrorResumeNext<T extends (this: V) => U | Promise<U>, U = unknown, V = undefined>(
+  fn: T,
+  context: V
+): U | undefined | Promise<U | undefined> {
+  try {
+    const result = fn.call(context);
+
+    if (isPromise(result)) {
+      return new Promise<U | undefined>(resolve => result.then(resolve, () => resolve(undefined)));
+    }
+
+    return result;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/on-error-resume-next/src/index.spec.ts
+++ b/packages/on-error-resume-next/src/index.spec.ts
@@ -41,7 +41,10 @@ describe('resolve', () => {
     thisArg = {};
   });
 
-  test('should throw', () => expect(() => onErrorResumeNext(fn, thisArg)).toThrow());
+  test('should throw', () =>
+    expect(() => onErrorResumeNext(fn, thisArg)).toThrow(
+      'Promise is not supported, please use "on-error-resume-next/async" instead.'
+    ));
 });
 
 describe('reject', () => {
@@ -53,5 +56,8 @@ describe('reject', () => {
     thisArg = {};
   });
 
-  test('should throw', () => expect(() => onErrorResumeNext(fn, thisArg)).toThrow());
+  test('should throw', () =>
+    expect(() => onErrorResumeNext(fn, thisArg)).toThrow(
+      'Promise is not supported, please use "on-error-resume-next/async" instead.'
+    ));
 });

--- a/packages/on-error-resume-next/src/index.spec.ts
+++ b/packages/on-error-resume-next/src/index.spec.ts
@@ -1,13 +1,57 @@
 import { onErrorResumeNext } from './index';
 
-test('parse JSON succeeded', () => {
-  const actual = onErrorResumeNext(() => JSON.parse('"Hello, World!"'));
+describe('return', () => {
+  let actual: string | undefined;
+  let fn: jest.Mock<string>;
+  let thisArg: object;
 
-  expect(actual).toBe('Hello, World!');
+  beforeEach(() => {
+    fn = jest.fn(() => JSON.parse('"Hello, World!"'));
+    thisArg = {};
+    actual = onErrorResumeNext(fn, thisArg);
+  });
+
+  test('should return the result', () => expect(actual).toBe('Hello, World!'));
+  test('should call the function once', () => expect(fn).toHaveBeenCalledTimes(1));
+  test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
 });
 
-test('parse JSON failed', () => {
-  const actual = onErrorResumeNext(() => JSON.parse('error'));
+describe('throw', () => {
+  let actual: string | undefined;
+  let fn: jest.Mock<string>;
+  let thisArg: object;
 
-  expect(actual).toBeUndefined();
+  beforeEach(() => {
+    fn = jest.fn(() => JSON.parse('error'));
+    thisArg = {};
+    actual = onErrorResumeNext(fn, thisArg);
+  });
+
+  test('should return undefined', () => expect(actual).toBeUndefined());
+  test('should call the function once', () => expect(fn).toHaveBeenCalledTimes(1));
+  test('should call the function with context', () => expect(fn.mock.contexts[0]).toBe(thisArg));
+});
+
+describe('resolve', () => {
+  let fn: jest.Mock<Promise<number>>;
+  let thisArg: object;
+
+  beforeEach(() => {
+    fn = jest.fn(() => Promise.resolve(1));
+    thisArg = {};
+  });
+
+  test('should throw', () => expect(() => onErrorResumeNext(fn, thisArg)).toThrow());
+});
+
+describe('reject', () => {
+  let fn: jest.Mock<Promise<unknown>>;
+  let thisArg: object;
+
+  beforeEach(() => {
+    fn = jest.fn(() => Promise.reject(new Error('error')).catch(() => {}));
+    thisArg = {};
+  });
+
+  test('should throw', () => expect(() => onErrorResumeNext(fn, thisArg)).toThrow());
 });

--- a/packages/on-error-resume-next/src/index.ts
+++ b/packages/on-error-resume-next/src/index.ts
@@ -1,3 +1,5 @@
+import isPromise from './private/isPromise';
+
 export function onErrorResumeNext<T extends () => U, U = unknown>(fn: T, context?: undefined): U | undefined;
 export function onErrorResumeNext<T extends (this: V) => U, U = unknown, V = undefined>(
   fn: T,
@@ -8,9 +10,17 @@ export function onErrorResumeNext<T extends (this: V) => U, U = unknown, V = und
   fn: T,
   context: V
 ): U | undefined {
+  let result: U;
+
   try {
-    return fn.call(context);
+    result = fn.call(context);
   } catch {
-    return;
+    return undefined;
   }
+
+  if (isPromise(result)) {
+    throw new Error('Promise is not supported, please use "on-error-resume-next/async" instead.');
+  }
+
+  return result;
 }

--- a/packages/on-error-resume-next/src/private/isPromise.spec.ts
+++ b/packages/on-error-resume-next/src/private/isPromise.spec.ts
@@ -1,0 +1,13 @@
+import isPromise from './isPromise';
+
+test('passing a Promise object should return true', () => expect(isPromise(new Promise(() => {}))).toBe(true));
+test('passing Promise.reject should return true', () => expect(isPromise(Promise.reject().catch(() => {}))).toBe(true));
+test('passing Promise.resolve should return true', () => expect(isPromise(Promise.resolve())).toBe(true));
+test('passing an empty object should return false', () => expect(isPromise({})).toBe(false));
+
+test('passing a boolean should return false', () => expect(isPromise(true)).toBe(false));
+test('passing a Date object should return false', () => expect(isPromise(new Date())).toBe(false));
+test('passing a number should return false', () => expect(isPromise(0)).toBe(false));
+test('passing a string should return false', () => expect(isPromise('')).toBe(false));
+test('passing null should return false', () => expect(isPromise(null)).toBe(false));
+test('passing undefined should return false', () => expect(isPromise(undefined)).toBe(false));

--- a/packages/on-error-resume-next/src/private/isPromise.ts
+++ b/packages/on-error-resume-next/src/private/isPromise.ts
@@ -1,0 +1,8 @@
+export default function isPromise(value: unknown): value is PromiseLike<unknown> {
+  return !!(
+    (typeof value === 'function' || typeof value === 'object') &&
+    value &&
+    'then' in value &&
+    typeof value.then === 'function'
+  );
+}

--- a/packages/on-error-resume-next/tsup.config.ts
+++ b/packages/on-error-resume-next/tsup.config.ts
@@ -5,7 +5,8 @@ export default defineConfig([
     dts: true,
     entry: {
       'on-error-resume-next': './src/index.ts',
-      'on-error-resume-next.async': './src/index.async.ts'
+      'on-error-resume-next.async': './src/index.async.ts',
+      'on-error-resume-next.auto': './src/index.auto.ts'
     },
     format: ['cjs', 'esm'],
     sourcemap: true


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Breaking changes

- Inrtoduced named exports and removed default imports
- Synchronous and asynchronous are now separated into different exports
   - Use `import { onErrorResumeNext } from 'on-error-resume-next'` for synchronous functions
   - Use `import { onErrorResumeNext } from 'on-error-resume-next/async'` for asynchronous functions, will always return `Promise` regardless the resolution and rejection is handled synchronously or asynchronously
   - Use `import { onErrorResumeNext } from 'on-error-resume-next/auto'` to auto-detect (legacy behavior), will return on `return`/`throw`, and resolve on `resolve`/`reject`

If you are using v1, you will need to port your code as follow:

```diff
- import onErrorResumeNext from 'on-error-resume-next';
+ import { onErrorResumeNext } from 'on-error-resume-next/auto';
```

### Added

- Added synchronous and asynchronous versions, in PR [#24](https://github.com/compulim/on-error-resume-next/pull/24) and [#25](https://github.com/compulim/on-error-resume-next/pull/25)

## Specific changes

> Please list each individual specific change in this pull request.

- Added `import { onErrorResumeNext } from 'on-error-resume-next/auto'`
- When passing an async function to sync version, will throw to protect from false negatives