### PR TITLE
Rename breaking changes to deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Breaking changes
+### Deprecated
 
-- Inrtoduced named exports and removed default imports
+- Introduced named exports and removed default imports
 - Synchronous and asynchronous are now separated into different exports
    - Use `import { onErrorResumeNext } from 'on-error-resume-next'` for synchronous functions
    - Use `import { onErrorResumeNext } from 'on-error-resume-next/async'` for asynchronous functions, will always return `Promise` regardless the resolution and rejection is handled synchronously or asynchronously


### PR DESCRIPTION
`keep-a-changelog` does not have "Breaking changes" section.

## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

## Specific changes

> Please list each individual specific change in this pull request.

- Renamed "Breaking changes" to "Deprecated"
- Fixed typo