### PR TITLE
Fix `import isPromise`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed [#30](https://github.com/compulim/on-error-resume-next/issues/30). When bundling for browser, should not fail with `isPromise` being imported from Node.js, in PR [#31](https://github.com/compulim/on-error-resume-next/pull/31).
+
 ## [2.0.0] - 2024-06-01
 
 ### Added

--- a/packages/on-error-resume-next/src/index.async.ts
+++ b/packages/on-error-resume-next/src/index.async.ts
@@ -1,4 +1,4 @@
-import { isPromise } from 'util/types';
+import isPromise from './private/isPromise';
 
 export function onErrorResumeNext<T extends () => Promise<U>, U = unknown>(
   fn: T,

--- a/packages/on-error-resume-next/src/tsconfig.json
+++ b/packages/on-error-resume-next/src/tsconfig.json
@@ -7,7 +7,8 @@
     "moduleResolution": "Bundler",
     "noEmit": true,
     "strict": true,
-    "target": "ESNext"
+    "target": "ESNext",
+    "types": []
   },
   "extends": "@tsconfig/strictest/tsconfig.json"
 }


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Fixed

- Fixed [#30](https://github.com/compulim/on-error-resume-next/issues/30). When bundling for browser, should not fail with `isPromise` being imported from Node.js, in PR [#31](https://github.com/compulim/on-error-resume-next/pull/31).

## Specific changes

> Please list each individual specific change in this pull request.

- Changed to import from `./private/isPromise`