### PR TITLE
fix: import in previous webpack versions

### DIFF
--- a/packages/on-error-resume-next/async.js
+++ b/packages/on-error-resume-next/async.js
@@ -1,0 +1,2 @@
+// This is required for Webpack 4 which does not support named exports.
+module.exports = require('./dist/on-error-resume-next.async.js');

--- a/packages/on-error-resume-next/auto.js
+++ b/packages/on-error-resume-next/auto.js
@@ -1,0 +1,2 @@
+// This is required for Webpack 4 which does not support named exports.
+module.exports = require('./dist/on-error-resume-next.auto.js');

--- a/packages/on-error-resume-next/package.json
+++ b/packages/on-error-resume-next/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.0-0",
   "description": "Run a function, synchronously or asynchronously, and ignore errors.",
   "files": [
-    "./dist/"
+    "./dist/",
+    "./*.js"
   ],
   "exports": {
     ".": {


### PR DESCRIPTION
## Changelog

- Fixed import errors in old webpack versions, in PR [#41](https://github.com/compulim/on-error-resume-next/pull/41) by [@OEvgeny](https://github.com/OEvgeny).

## Specific changes

- Added `async.js` and `auto.js` files for Webpack 4 to be able to load the corresponding package entries.